### PR TITLE
add tasks to deploy constants

### DIFF
--- a/deploy-constants.yaml
+++ b/deploy-constants.yaml
@@ -43,3 +43,5 @@ packages:
     tags: *latest
   "zos-make-for-zowe-cli":
     tags: *latest
+  "tasks-for-zowe-cli":
+    tags: *latest


### PR DESCRIPTION
Signed-off-by: Jason Tucker <jason.tucker@broadcom.com>

Adds `zowe-task` for deployment. 