### PR TITLE
Handle public and non public repos for changelog checking

### DIFF
--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -531,7 +531,8 @@ class GenericPipeline extends Pipeline {
         if (changeInfo.isPullRequest) {
             createStage(name: "Check Changelog", stage: {
                 try {
-                    def fetchOutput = steps.sh(returnStderr: true, script: "git --no-pager fetch").trim()
+                    def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch 2>&1").trim()
+                    steps.echo fetchOutput
                     if (fetchOutput.toLowerCase().contains("could not read username")) {
                         configureGit(true, true)
                     }

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -507,9 +507,9 @@ class GenericPipeline extends Pipeline {
         def repo = scmHead.getSourceRepo()
         def prId = scmHead.getId()
 
-        def scmUrl = scm.getUserRemoteConfigs()[0].getUrl()
+        def scmUrl = steps.scm.getUserRemoteConfigs()[0].getUrl()
         steps.echo "OMG ----------- ${scmUrl}"
-        def apiUrl = scm.getApi().getSearchUrl()
+        def apiUrl = steps.scm.getApi().getSearchUrl()
         steps.echo "OMG ----------- ${apiUrl}"
         steps.withCredentials([steps.usernamePassword(credentialsId: gitConfig.credentialsId, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
             def json = steps.sh(returnStdout: true, script: "curl -u \$USERNAME:\$PASSWORD https://api.github.com/repos/zowe/${repo}/issues/${prId}")

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -531,7 +531,7 @@ class GenericPipeline extends Pipeline {
         if (changeInfo.isPullRequest) {
             createStage(name: "Check Changelog", stage: {
                 try {
-                    def fetchOutput = steps.sh(returnStdout: true, "git --no-pager fetch").trim()
+                    def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch").trim()
                     if (fetchOutput.toLowerCase().contains("could not read username")) {
                         configureGit(true, true)
                     }

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -531,13 +531,14 @@ class GenericPipeline extends Pipeline {
         if (changeInfo.isPullRequest) {
             createStage(name: "Check Changelog", stage: {
                 try {
-                    def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch").trim()
+                    def fetchOutput = steps.sh(returnStderr: true, script: "git --no-pager fetch").trim()
                     if (fetchOutput.toLowerCase().contains("could not read username")) {
                         configureGit(true, true)
                     }
                 } catch (err) {
-                    steps.error "OMG ------------ ${err.message}"
+                    steps.error "OMG ------------ ${err}"
                 }
+                steps.error "NO THROW"
                 String target = steps.CHANGE_TARGET
                 String changedFiles = steps.sh(returnStdout: true, script: "git --no-pager diff origin/${target} --name-only").trim()
                 String labels = getLabels()

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -532,14 +532,12 @@ class GenericPipeline extends Pipeline {
             createStage(name: "Check Changelog", stage: {
                 try {
                     def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch 2>&1 || exit 0").trim()
-                    steps.echo fetchOutput
                     if (fetchOutput.toLowerCase().contains("could not read username")) {
                         configureGit(true, true)
                     }
                 } catch (err) {
-                    steps.error "OMG ------------ ${err}"
+                    steps.error "${err.message}"
                 }
-                steps.error "NO THROW"
                 String target = steps.CHANGE_TARGET
                 String changedFiles = steps.sh(returnStdout: true, script: "git --no-pager diff origin/${target} --name-only").trim()
                 String labels = getLabels()
@@ -571,7 +569,7 @@ class GenericPipeline extends Pipeline {
         }
 
         // Setup the branch to track it's remote
-        if (stayInContext) steps.sh "git checkout ${changeInfo.branchName}"
+        if (!stayInContext) steps.sh "git checkout ${changeInfo.branchName}"
         steps.sh "git status"
 
         // If the branch is protected, setup the proper configuration

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -595,7 +595,7 @@ class GenericPipeline extends Pipeline {
             steps.sh "git status"
 
             // If the branch is protected, setup the proper configuration
-            if (_isProtectedBranch) {
+            // if (_isProtectedBranch) {
                 String remoteUrl = steps.sh(returnStdout: true, script: "git remote get-url --all origin").trim()
 
                 // Only execute the credential code if the url does not already contain credentials
@@ -604,7 +604,7 @@ class GenericPipeline extends Pipeline {
                 // Set the push url to the correct one
                 steps.sh "git remote set-url --add origin $remoteUrlWithCreds"
                 steps.sh "git remote set-url --delete origin $remoteUrl"
-            }
+            // }
         }, isSkippable: false, timeout: timeouts.gitSetup, shouldExecute: {
             // Disable commits and pushes
             // return !changeInfo.isPullRequest

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -607,7 +607,8 @@ class GenericPipeline extends Pipeline {
             }
         }, isSkippable: false, timeout: timeouts.gitSetup, shouldExecute: {
             // Disable commits and pushes
-            return !changeInfo.isPullRequest
+            // return !changeInfo.isPullRequest
+            return true
         })
 
         createStage(name: 'Check for CI Skip', stage: {

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -531,7 +531,7 @@ class GenericPipeline extends Pipeline {
         if (changeInfo.isPullRequest) {
             createStage(name: "Check Changelog", stage: {
                 try {
-                    def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch 2>&1").trim()
+                    def fetchOutput = steps.sh(returnStdout: true, script: "git --no-pager fetch 2>&1 || exit 0").trim()
                     steps.echo fetchOutput
                     if (fetchOutput.toLowerCase().contains("could not read username")) {
                         configureGit(true, true)

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -508,8 +508,7 @@ class GenericPipeline extends Pipeline {
         def prId = scmHead.getId()
 
         def scmUrl = steps.scm.getUserRemoteConfigs()[0].getUrl()
-        steps.echo "OMG ----------- ${scmUrl}"
-        def apiUrl = steps.scm.getApi().getSearchUrl()
+        def apiUrl = steps.scm.getApi().doJson()
         steps.echo "OMG ----------- ${apiUrl}"
         steps.withCredentials([steps.usernamePassword(credentialsId: gitConfig.credentialsId, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
             def json = steps.sh(returnStdout: true, script: "curl -u \$USERNAME:\$PASSWORD https://api.github.com/repos/zowe/${repo}/issues/${prId}")

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -591,7 +591,7 @@ class GenericPipeline extends Pipeline {
             }
 
             // Setup the branch to track it's remote
-            steps.sh "git checkout ${changeInfo.branchName}"
+            if (!changeInfo.isPullRequest) steps.sh "git checkout ${changeInfo.branchName}"
             steps.sh "git status"
 
             // If the branch is protected, setup the proper configuration

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -507,7 +507,11 @@ class GenericPipeline extends Pipeline {
         def repo = scmHead.getSourceRepo()
         def prId = scmHead.getId()
 
-        steps.withCredentials([steps.usernamePassword(credentialsId: 'zowe-robot-github', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+        def scmUrl = scm.getUserRemoteConfigs()[0].getUrl()
+        steps.echo "OMG ----------- ${scmUrl}"
+        def apiUrl = scm.getApi().getSearchUrl()
+        steps.echo "OMG ----------- ${apiUrl}"
+        steps.withCredentials([steps.usernamePassword(credentialsId: gitConfig.credentialsId, usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
             def json = steps.sh(returnStdout: true, script: "curl -u \$USERNAME:\$PASSWORD https://api.github.com/repos/zowe/${repo}/issues/${prId}")
             def prInfo = steps.readJSON(text: json)
             labels = prInfo.labels


### PR DESCRIPTION
** NOTE ** `no-changelog` label does not work on GitHub APIs other than `api.github.com`, forcing the chnagelog check to occur even when the no-changelog label is specified.

UPDATE: GHE APIs are now handled. Will default to checking for changelog should something go wrong with the APIs