### PR TITLE
Move update changelog into version stage

### DIFF
--- a/src/org/zowe/pipelines/nodejs/arguments/NodeJSVersionStageArguments.groovy
+++ b/src/org/zowe/pipelines/nodejs/arguments/NodeJSVersionStageArguments.groovy
@@ -1,0 +1,25 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.pipelines.nodejs.arguments
+
+/**
+ * Represents the arguments available to the
+ * {@link org.zowe.pipelines.nodejs.NodeJSPipeline#version(java.util.Map)} method.
+ */
+class NodeJSVersionStageArguments extends VersionStageArguments {
+    /**
+     * If any arguments are defined, the update changelog stage will be invoked
+     * with them.
+     *
+     * @default {@code [:]}
+     */
+    Map<String, String> updateChangelogArgs = [:]
+}


### PR DESCRIPTION
This PR deprecates the method `NodeJSPipeline.updateChangelog` in favor of adding `updateChangelogArgs` as an arg to the version stage.

This change is necessary for Lerna monorepos, which check for packages that have changed since the most recent Git tag. When a changelog version bump for package X is committed after the version stage has created a tag, this causes Lerna to incorrectly think that package X has changed the next time that a PR is created which changes package Y.

Moving the update changelog logic into the version stage also makes it possible to perform all version bumps in a single commit, instead of two.