### PR TITLE
Fix lerna change detection

### DIFF
--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -556,7 +556,7 @@ class GenericPipeline extends Pipeline {
 
                 String target = steps.CHANGE_TARGET
                 String changedFiles = steps.sh(returnStdout: true, script: "git --no-pager diff origin/${target} --name-only").trim()
-                String[] projectDirs = getProjectDirs()
+                String[] projectDirs = getChangedDirs()
                 if (labels != null && labels.contains("no-changelog")) {
                     steps.echo "no-changelog label found on Pull Request. Skipping changelog check."
                 } else if (projectDirs.length == 0) {
@@ -896,7 +896,7 @@ class GenericPipeline extends Pipeline {
      * If the list is empty, only the root directory is checked.
      * For a monorepo project, override this method to return a non-empty list.
      */
-    String[] getProjectDirs() {
+    String[] getChangedDirs() {
         return []
     }
 }

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -1205,11 +1205,12 @@ expect {
      */
     protected List<Map> _buildLernaPkgInfo(LernaFilter filter) {
         def lernaCmd = "list"
-        if (filter != LernaFilter.ALL) {
-            lernaCmd += " --since origin/${steps.CHANGE_TARGET}"
-        }
-        if (filter == LernaFilter.CHANGED_EXCLUDE_DEPENDENTS) {
-            lernaCmd += " --exclude-dependents"
+        if (filter == LernaFilter.CHANGED) {
+            lernaCmd += " --since --include-merged-tags"
+        } else if (filter == LernaFilter.CHANGED_EXCLUDE_DEPENDENTS) {
+            lernaCmd += " --since --exclude-dependents --include-merged-tags"
+        } else if (filter == LernaFilter.CHANGED_IN_BRANCH) {
+            lernaCmd += " --since origin/${steps.CHANGE_TARGET} --exclude-dependents"
         }
         def cmdOutput = steps.sh(returnStdout: true, script: "npx lerna ${lernaCmd} --json --toposort").trim()
         return steps.readJSON(text: cmdOutput)
@@ -1284,7 +1285,7 @@ expect {
      */
     String[] getChangedDirs() {
         if (isLernaMonorepo) {
-            return _lernaPkgInfo[LernaFilter.CHANGED_EXCLUDE_DEPENDENTS].collect { it.location } as String[]
+            return _lernaPkgInfo[LernaFilter.CHANGED_IN_BRANCH].collect { it.location } as String[]
         }
 
         return super.getChangedDirs()

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -583,7 +583,7 @@ class NodeJSPipeline extends GenericPipeline {
                 }
 
                 // Revert package.json files to their old contents
-                steps.sh "git checkout **/package.json"
+                steps.sh "git reset --hard"
             }
         }
 

--- a/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
+++ b/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
@@ -20,12 +20,19 @@ enum LernaFilter {
     ALL,
 
     /**
-     * List only changed packages (may include transitive dependents).
+     * List only packages that have changed since the last Git tag.
+     * May include transitive dependents.
      */
     CHANGED,
 
     /**
-     * List only changed packages and exclude all transitive dependents.
+     * List only packages that have changed since the last Git tag.
+     * Excludes transitive dependents.
      */
-    CHANGED_EXCLUDE_DEPENDENTS
+    CHANGED_EXCLUDE_DEPENDENTS,
+
+    /**
+     * List only packages that have changed in this branch or PR.
+     */
+    CHANGED_IN_BRANCH
 }

--- a/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
+++ b/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
@@ -1,0 +1,31 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+package org.zowe.pipelines.nodejs.enums
+
+/**
+ * The options available to filter output of "lerna list" command.
+ */
+enum LernaFilter {
+    /**
+     * List all packages.
+     */
+    ALL,
+
+    /**
+     * List only changed packages (may include transitive dependents).
+     */
+    CHANGED,
+
+    /**
+     * List only changed packages and exclude all transitive dependents.
+     */
+    CHANGED_EXCLUDE_DEPENDENTS
+}


### PR DESCRIPTION
This PR defines multiple Lerna filters:
* ALL - used for build, vuln check
* CHANGED - used for deploy
* CHANGED_EXCLUDE_DEPENDENTS - used for update changelog (to exclude packages whose only changes are updates to same-monorepo dependencies)
* CHANGED_IN_BRANCH - used for check changelog (to exclude package changes that have already been merged into master)
