### PR TITLE
Use lerna changed rather than list to respect ignoreChanges setting

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -1191,7 +1191,7 @@ expect {
      * @param args Object of type {@link org.zowe.pipelines.generic.arguments.ChangelogStageArguments}
      */
     void _updateChangelog(ChangelogStageArguments args) {
-        runForEachMonorepoPackage(LernaFilter.CHANGED_EXCLUDE_DEPENDENTS) {
+        runForEachMonorepoPackage(LernaFilter.CHANGED) {
             String contents = steps.sh(returnStdout: true, script: "cat ${args.file}").trim()
             def packageJSON = steps.readJSON file: 'package.json'
             def packageJSONVersion = packageJSON.version
@@ -1216,16 +1216,14 @@ expect {
      * @Note Each object contains these keys: name, version, private, location
      */
     protected List<Map> _buildLernaPkgInfo(LernaFilter filter) {
-        def lernaCmd = "list"
+        def lernaCmd
         if (filter == LernaFilter.CHANGED) {
-            lernaCmd += " --since --include-merged-tags"
-        } else if (filter == LernaFilter.CHANGED_EXCLUDE_DEPENDENTS) {
-            lernaCmd += " --since --exclude-dependents --include-merged-tags"
+            lernaCmd = "changed --include-merged-tags"
         } else if (filter == LernaFilter.CHANGED_IN_PR) {
             if (!steps.env.CHANGE_TARGET) {
                 return null;  // This filter isn't supported in branch builds
             }
-            lernaCmd += " --since origin/${steps.CHANGE_TARGET} --exclude-dependents"
+            lernaCmd = "list --since origin/${steps.CHANGE_TARGET} --exclude-dependents"
         }
         def cmdOutput = steps.sh(returnStdout: true, script: "npx lerna ${lernaCmd} --json --toposort").trim()
         return steps.readJSON(text: cmdOutput)

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -1217,13 +1217,21 @@ expect {
      */
     protected List<Map> _buildLernaPkgInfo(LernaFilter filter) {
         def lernaCmd
-        if (filter == LernaFilter.CHANGED) {
-            lernaCmd = "changed --include-merged-tags"
-        } else if (filter == LernaFilter.CHANGED_IN_PR) {
-            if (!steps.env.CHANGE_TARGET) {
-                return null;  // This filter isn't supported in branch builds
-            }
-            lernaCmd = "list --since origin/${steps.CHANGE_TARGET} --exclude-dependents"
+        switch (filter) {
+            case LernaFilter.ALL:
+                lernaCmd = "list"
+                break
+            case LernaFilter.CHANGED:
+                lernaCmd = "changed --include-merged-tags"
+                break
+            case LernaFilter.CHANGED_IN_PR:
+                if (!steps.env.CHANGE_TARGET) {
+                    return null  // This filter isn't supported in branch builds
+                }
+                lernaCmd = "list --since origin/${steps.CHANGE_TARGET} --exclude-dependents"
+                break
+            default:
+                steps.error "Invalid Lerna filter specified: ${filter}"
         }
         def cmdOutput = steps.sh(returnStdout: true, script: "npx lerna ${lernaCmd} --json --toposort").trim()
         return steps.readJSON(text: cmdOutput)

--- a/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
+++ b/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
@@ -21,15 +21,8 @@ enum LernaFilter {
 
     /**
      * List only packages that have changed since the last Git tag.
-     * May include transitive dependents.
      */
     CHANGED,
-
-    /**
-     * List only packages that have changed since the last Git tag.
-     * Excludes transitive dependents.
-     */
-    CHANGED_EXCLUDE_DEPENDENTS,
 
     /**
      * List only packages that have changed in this PR.


### PR DESCRIPTION
The `ignoreChanges` setting in Lerna is respected by `lerna changed`, but not by `lerna list`.

Switch back to using `lerna changed` to determine what packages need to be versioned/deployed.

Keep using `lerna list --since` for checking what has changed in a PR since we need to compare to a specific ref. Unfortunately this will trigger if changes were made only to tests or to package-lock files, but we can work around this for now with the no-changelog label.