### PR TITLE
NVM and Java 11

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -886,7 +886,7 @@ class NodeJSPipeline extends GenericPipeline {
         createStage(name: 'Install Node Package Dependencies', stage: {
             if (arguments.nodeJsVersion && arguments.nvmDir) {
                 // https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
-                steps.sh "source ${arguments.nvmDir}/nvm.sh && nvm install ${arguments.nodeJsVersion} && nvm use ${arguments.nodeJsVersion}"
+                steps.sh ". ${arguments.nvmDir}/nvm.sh && nvm install ${arguments.nodeJsVersion} && nvm use ${arguments.nodeJsVersion}"
                 steps.env.NODE_PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/lib/node_modules"
                 steps.env.PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/bin:${steps.env.PATH}"
             }

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -1068,7 +1068,7 @@ class NodeJSPipeline extends GenericPipeline {
 
                 def scannerHome = steps.tool 'sonar-scanner-4.0.0'
                 steps.withSonarQubeEnv('sonarcloud-server') {
-                    steps.sh "${scannerHome}/bin/sonar-scanner"
+                    steps.sh "JAVA_HOME=/usr/java/openjdk-11 && ${scannerHome}/bin/sonar-scanner"
                 }
             }
         )

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -880,10 +880,17 @@ class NodeJSPipeline extends GenericPipeline {
      *     </dd>
      * </dl>
      */
-    void setup(NodeJSSetupArguments timeouts) {
-        super.setupGeneric(timeouts)
+    void setup(NodeJSSetupArguments arguments) {
+        super.setupGeneric(arguments)
 
         createStage(name: 'Install Node Package Dependencies', stage: {
+            if (arguments.nodeJsVersion && arguments.nvmDir) {
+                // https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
+                steps.sh "source ${arguments.nvmDir}/nvm.sh && nvm install ${arguments.nodeJsVersion} && nvm use ${arguments.nodeJsVersion}"
+                steps.env.NODE_PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/lib/node_modules"
+                steps.env.PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/bin:${steps.env.PATH}"
+            }
+
             try {
                 // Keep track of when the default registry is used since it is only allowed to be used once
                 def didUseDefaultRegistry = false
@@ -973,7 +980,7 @@ class NodeJSPipeline extends GenericPipeline {
                     }
                 }
             }
-        }, isSkippable: false, timeout: timeouts.installDependencies)
+        }, isSkippable: false, timeout: arguments.installDependencies)
     }
 
     /**

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -1075,7 +1075,7 @@ class NodeJSPipeline extends GenericPipeline {
 
                 def scannerHome = steps.tool 'sonar-scanner-4.0.0'
                 steps.withSonarQubeEnv('sonarcloud-server') {
-                    steps.sh "JAVA_HOME=/usr/java/openjdk-11 && ${scannerHome}/bin/sonar-scanner"
+                    steps.sh "JAVA_HOME=/usr/java/openjdk-11 && PATH=\${JAVA_HOME}/bin:\$PATH && ${scannerHome}/bin/sonar-scanner"
                 }
             }
         )

--- a/src/org/zowe/pipelines/nodejs/arguments/NodeJSSetupArguments.groovy
+++ b/src/org/zowe/pipelines/nodejs/arguments/NodeJSSetupArguments.groovy
@@ -27,4 +27,16 @@ class NodeJSSetupArguments extends GenericSetupArguments {
      * @default 5 Minutes
      */
     StageTimeout installDependencies = [time: 5, unit: TimeUnit.MINUTES]
+
+    /**
+     * Node.js version to install using NVM.
+     */
+    String nodeJsVersion
+
+    /**
+     * Path to NVM directory.
+     *
+     * @default {@code "/home/jenkins/.nvm"}
+     */
+    String nvmDir = "/home/jenkins/.nvm"
 }


### PR DESCRIPTION
Fixes #117 and resolves #116.

SonarCloud no longer accepts Java 8, so it was necessary to migrate to a newer agent `zowe-jenkins-agent` that has Java 11.

The new Jenkins agent defaults to Node.js 8, but Zowe CLI requires Node.js 10 or newer. To resolve this, a `nodeJsVersion` argument was added that can be passed to `NodeJSPipeline.setup`. When `nodeJsVersion` is specified, NVM will be invoked to install and activate the desired NPM version.

A few small changes will be required in Zowe CLI pipelines to use the new Jenkins agent: https://github.com/zowe/zowe-cli/compare/sonar-jdk11.

A successful build log from the new agent can be found here: https://wash.zowe.org:8443/blue/organizations/jenkins/brightside/detail/sonar-jdk11/10/pipeline/75