### PR TITLE
Include merged tags in lerna version change detection

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -505,7 +505,7 @@ class NodeJSPipeline extends GenericPipeline {
                     // the tag to point to an invalid commit hash.
                     steps.sh "npm version ${steps.env.DEPLOY_VERSION} --allow-same-version --no-git-tag-version"
                 } else {
-                    steps.sh "npx lerna version ${steps.env.DEPLOY_VERSION} --exact --no-git-tag-version --yes"
+                    steps.sh "npx lerna version ${steps.env.DEPLOY_VERSION} --exact --include-merged-tags --no-git-tag-version --yes"
                 }
                 steps.sh "git add -u"  // Safe because we ran "git reset" above
                 if (arguments.updateChangelogArgs) {


### PR DESCRIPTION
We deploy packages that match the filter `LernaFilter.CHANGED`:
https://github.com/zowe/zowe-cli-version-controller/blob/dffc786a88f285e458f702627632a5b16ae95a59/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy#L745-L750

The command used to find the set of "changed" packages is `lerna changed --include-merged-tags`:
https://github.com/zowe/zowe-cli-version-controller/blob/dffc786a88f285e458f702627632a5b16ae95a59/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy#L1237-L1239

The "--include-merged-tags" flag helps Lerna to perform smarter change detection. From [Lerna docs](https://github.com/lerna/lerna/tree/main/commands/version#--include-merged-tags):
> ### `--include-merged-tags`
> 
> ```sh
> lerna version --include-merged-tags
> ```
> 
> Include tags from merged branches when detecting changed packages.

We should be bumping versions on the same set of packages that are going to be deployed. The `lerna version` command was missing the "--include-merged-tags" flag, which may have been causing it to detect too many changes.

The change in this PR should restrict the set of packages whose versions are bumped to always match the set of packages being deployed.