### PR TITLE
Use NPM workspaces for easier monorepo handling

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -931,7 +931,7 @@ class NodeJSPipeline extends GenericPipeline {
                         // Update dependencies to have matching versions across all packages
                         def depList = branchProps.dependencies.keySet() + branchProps.devDependencies.keySet()
                         if (depList.size() > 0) {
-                            steps.sh "npx syncpack fix-mismatches --dev --prod --filter \"${depList.join('|')}\""
+                            steps.sh "npx -y -- syncpack fix-mismatches --dev --prod --filter \"${depList.join('|')}\""
                             steps.sh "npm install --package-lock-only"
                             // Rebuild list of changed packages to be deployed
                             _lernaPkgInfo[LernaFilter.CHANGED] = _buildLernaPkgInfo(LernaFilter.CHANGED)

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -876,6 +876,10 @@ class NodeJSPipeline extends GenericPipeline {
                 steps.env.PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/bin:${steps.env.PATH}"
             }
 
+            if (arguments.npmVersion) {
+                steps.sh "npm install -g npm@${arguments.npmVersion}"
+            }
+
             try {
                 // Keep track of when the default registry is used since it is only allowed to be used once
                 def didUseDefaultRegistry = false

--- a/src/org/zowe/pipelines/nodejs/arguments/NodeJSSetupArguments.groovy
+++ b/src/org/zowe/pipelines/nodejs/arguments/NodeJSSetupArguments.groovy
@@ -39,4 +39,9 @@ class NodeJSSetupArguments extends GenericSetupArguments {
      * @default {@code "/home/jenkins/.nvm"}
      */
     String nvmDir = "/home/jenkins/.nvm"
+
+    /**
+     * NPM version to install (e.g., "^7")
+     */
+    String npmVersion
 }

--- a/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
+++ b/src/org/zowe/pipelines/nodejs/enums/LernaFilter.groovy
@@ -21,15 +21,8 @@ enum LernaFilter {
 
     /**
      * List only packages that have changed since the last Git tag.
-     * May include transitive dependents.
      */
     CHANGED,
-
-    /**
-     * List only packages that have changed since the last Git tag.
-     * Excludes transitive dependents.
-     */
-    CHANGED_EXCLUDE_DEPENDENTS,
 
     /**
      * List only packages that have changed in this PR.


### PR DESCRIPTION
Use npm@7 workspaces for install and audit because it is simpler than using Lerna for these tasks. Lerna is still used for change detection and versioning.

Also add `npmVersion` as an optional argument on `NodeJSSetupArguments`. Specifying "^7" in the CLI pipeline automates the installation of npm@7 so that workspaces can be used.