### PR TITLE
Fix npm workspaces

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -936,7 +936,7 @@ class NodeJSPipeline extends GenericPipeline {
                         def depList = branchProps.dependencies.keySet() + branchProps.devDependencies.keySet()
                         if (depList.size() > 0) {
                             steps.sh "npx -y -- syncpack fix-mismatches --dev --prod --filter \"${depList.join('|')}\""
-                            steps.sh "npm install --package-lock-only"
+                            steps.sh "npm install"
                             // Rebuild list of changed packages to be deployed
                             _lernaPkgInfo[LernaFilter.CHANGED] = _buildLernaPkgInfo(LernaFilter.CHANGED)
                         }

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -936,7 +936,8 @@ class NodeJSPipeline extends GenericPipeline {
                         def depList = branchProps.dependencies.keySet() + branchProps.devDependencies.keySet()
                         if (depList.size() > 0) {
                             steps.sh "npx -y -- syncpack fix-mismatches --dev --prod --filter \"${depList.join('|')}\""
-                            steps.sh "npm install"
+                            // Force NPM to recognize package-lock is outdated
+                            steps.sh "git checkout package-lock.json && npm install"
                             // Rebuild list of changed packages to be deployed
                             _lernaPkgInfo[LernaFilter.CHANGED] = _buildLernaPkgInfo(LernaFilter.CHANGED)
                         }


### PR DESCRIPTION
This fixes an issue encountered in https://github.com/zowe/zowe-cli/pull/1009.

In a PR build, when dependencies like Imperative are updated, the update needs to be propagated across all packages in the monorepo.

npm@7 workspaces seem to have a bug where in the following scenario, package-lock.json takes priority and isn't detected as being out of sync with package.json:
* `./package-lock.json`
  * `.` - @zowe/imperative@5
  * `./cli` - @zowe/imperative@4
  * `./core` - @zowe/imperative@4
* `./package.json`
  * @zowe/imperative@5
* `./cli/package.json`
  * @zowe/imperative@5
* `./core/package.json`
  * @zowe/imperative@5

This PR works around the issue by reverting changes to package-lock.json to force NPM to recognize that it's outdated.