### PR TITLE
Fix Imperative publish

### DIFF
--- a/scripts/deploy-zowe-cli-component.groovy
+++ b/scripts/deploy-zowe-cli-component.groovy
@@ -35,9 +35,9 @@ def rmProt(String url) {
 def opts = []
 opts.push(
     parameters([
-        string(name: 'PKG_NAME', defaultValue: 'cli', description: 'Name of the package to be deployed<br/><strong>Note:</strong> the <code>@zowe</code> scope will be prepended'),
-        string(name: 'PKG_TAG', defaultValue: 'daily', description: 'Tag to be distributed from artifactory'),
-        string(name: 'RECIPIENTS_LIST', defaultValue: '', description: 'List of emails to recevie build resutls (Override)')
+        string(name: 'PKG_NAME', defaultValue: 'cli', description: 'Name of the package to be deployed<br/><strong>Note:</strong> the <code>@zowe</code> scope will be prepended', trim: true),
+        string(name: 'PKG_TAG', defaultValue: 'daily', description: 'Tag to be distributed from artifactory', trim: true),
+        string(name: 'RECIPIENTS_LIST', defaultValue: '', description: 'List of emails to receive build resutls (Override)')
     ])
 )
 opts.push(buildDiscarder(logRotator(numToKeepStr: '20')))

--- a/scripts/deploy-zowe-cli-component.groovy
+++ b/scripts/deploy-zowe-cli-component.groovy
@@ -37,7 +37,7 @@ opts.push(
     parameters([
         string(name: 'PKG_NAME', defaultValue: 'cli', description: 'Name of the package to be deployed<br/><strong>Note:</strong> the <code>@zowe</code> scope will be prepended', trim: true),
         string(name: 'PKG_TAG', defaultValue: 'daily', description: 'Tag to be distributed from artifactory', trim: true),
-        string(name: 'RECIPIENTS_LIST', defaultValue: '', description: 'List of emails to receive build resutls (Override)')
+        string(name: 'RECIPIENTS_LIST', defaultValue: '', description: 'List of emails to receive build results (Override)')
     ])
 )
 opts.push(buildDiscarder(logRotator(numToKeepStr: '20')))

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -10,8 +10,6 @@
 #
 ###
 
-set -ex
-
 die () {
     echo "$@"
     exit 1
@@ -39,8 +37,6 @@ node -e "package = require('./package.json');
 mv package.json ../../$tarfile_package.json
 # Replace package json with our new one
 mv package_new.json package.json
-
-ls -la
 
 # Update npm-shrinkwrap.json if necessary
 if [ -e "npm-shrinkwrap.json" ]; then

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -28,8 +28,13 @@ tar xzf $tarfile -C temp
 cd temp
 cd package
 # Unholy one liner which replace registry and repository with blank strings. Should convert this to javascript file soonTM.
+# Also remove prepare script which may require dev dependencies like Husky - https://github.com/typicode/husky/issues/914
 # Takes in package.json, outputs package_new.json
-node -e "package = require('./package.json');package.publishConfig.registry='$registry';package.version='$newversion';require('fs').writeFile('package_new.json', JSON.stringify(package, null, 4), 'utf8')"
+node -e "package = require('./package.json');
+    package.publishConfig.registry='$registry';
+    package.version='$newversion';
+    delete package.scripts.prepare;
+    require('fs').writeFile('package_new.json', JSON.stringify(package, null, 4), 'utf8')"
 # Move the old package JSON to build dir so we can publish as a Jenkins artifact?
 mv package.json ../../$tarfile_package.json
 # Replace package json with our new one

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -10,6 +10,8 @@
 #
 ###
 
+set -ex
+
 die () {
     echo "$@"
     exit 1
@@ -32,6 +34,8 @@ node -e "package = require('./package.json');package.publishConfig.registry='$re
 mv package.json ../../$tarfile_package.json
 # Replace package json with our new one
 mv package_new.json package.json
+
+ls -la
 
 # Update npm-shrinkwrap.json if necessary
 if [ -e "npm-shrinkwrap.json" ]; then

--- a/scripts/repackage_tar.sh
+++ b/scripts/repackage_tar.sh
@@ -34,7 +34,7 @@ node -e "package = require('./package.json');
     package.publishConfig.registry='$registry';
     package.version='$newversion';
     delete package.scripts.prepare;
-    require('fs').writeFile('package_new.json', JSON.stringify(package, null, 4), 'utf8')"
+    require('fs').writeFileSync('package_new.json', JSON.stringify(package, null, 2), 'utf8')"
 # Move the old package JSON to build dir so we can publish as a Jenkins artifact?
 mv package.json ../../$tarfile_package.json
 # Replace package json with our new one


### PR DESCRIPTION
🚨 Before deleting the branch, update the branch used by https://wash.zowe.org:8443/job/zowe-cli-deploy-component/

* Remove "prepare" script from NPM package before publishing. This should be safe to remove, as the "prepare" script only runs during the development lifecycle. The change was necessary to prevent errors during `npm pack`, since the "prepare" script `husky install` fails when only prod (not dev) dependencies are installed.
* Use 2 spaces instead of 4 in package.json files, because that's the standard indentation used by `npm init`
* Trim PKG_NAME and PKG_TAG parameters. If PKG_TAG is not trimmed, specifying a version like " 5.0.0-next.XXX" with a leading space causes the version to get published as `@latest` 😨 