### PR TITLE
Allow alias tag specs to include package name

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -784,6 +784,14 @@ class NodeJSPipeline extends GenericPipeline {
                     // Apply alias tags, even if no new version was published
                     try {
                         for (String tag in branch.aliasTags) {
+                            if (tag.contains("@")) {
+                                def splitIndex = tag.lastIndexOf("@")
+                                if (tag.substring(0, splitIndex) == steps.env.DEPLOY_PACKAGE) {
+                                    tag = tag.substring(splitIndex + 1)
+                                } else {
+                                    continue
+                                }
+                            }
                             steps.sh "npm dist-tag add ${steps.env.DEPLOY_PACKAGE}@${steps.env.DEPLOY_VERSION} ${tag}"
                         }
                     } catch (Exception e) {

--- a/src/org/zowe/pipelines/nodejs/models/NodeJSProtectedBranch.groovy
+++ b/src/org/zowe/pipelines/nodejs/models/NodeJSProtectedBranch.groovy
@@ -72,6 +72,10 @@ class NodeJSProtectedBranch extends ProtectedBranch {
 
     /**
      * A list of additional tags that will be applied when the branch is published.
+     *
+     * <p>Specify tags without the "@" in front. Examples: "zowe-v1-lts", "next". For a monorepo,
+     * you can also specify tags for a specific package name (e.g., "@zowe/cli-test-utils@next").
+     * </p>
      */
     String[] aliasTags = []
 }


### PR DESCRIPTION
This allows Zowe CLI to publish the next tag with an alias `@zowe/cli-test-utils@latest` that applies only to one package.

Not able to test this change until the cli-test-utils package has changes so that Lerna tries to publish it. I've tested the new code in [a Groovy Replit](https://groovyconsole.appspot.com/) and it seems to work:
![image](https://user-images.githubusercontent.com/22344007/123491783-8fb28300-d5e5-11eb-8fcf-8df873d82a44.png)

