### PR TITLE
Fix smoke test failure in monorepo

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -789,7 +789,7 @@ class NodeJSPipeline extends GenericPipeline {
                         // Wait for a second to give NPM registry time to update package metadata
                         steps.sleep time: 1000, unit: TimeUnit.MILLISECONDS
 
-                        steps.dir(steps.pwd(tmp: true)) {
+                        steps.dir("/tmp/${BUILD_TAG}") {
                             if (deployArguments.customSmokeTest) {
                                 deployArguments.customSmokeTest()
                             } else {
@@ -799,6 +799,8 @@ class NodeJSPipeline extends GenericPipeline {
                                     steps.error "Version ${packageJSON.version} was installed instead of the deployed version"
                                 }
                             }
+
+                            steps.deleteDir()
                         }
                     }
                 } finally {

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -789,7 +789,7 @@ class NodeJSPipeline extends GenericPipeline {
                         // Wait for a second to give NPM registry time to update package metadata
                         steps.sleep time: 1000, unit: TimeUnit.MILLISECONDS
 
-                        steps.dir("/tmp/${BUILD_TAG}") {
+                        steps.dir("/tmp/${steps.env.BUILD_TAG}") {
                             if (deployArguments.customSmokeTest) {
                                 deployArguments.customSmokeTest()
                             } else {


### PR DESCRIPTION
I wrongly assumed that Jenkins would create a random directory in "/tmp" when `steps.pwd(tmp: true)` is called.

Instead, it creates a new directory "X@tmp" as a sibling of the current working directory named X.

In the CLI monorepo, this causes the smoke test to fail because the install is happening in a subdirectory of the repo where the project-level node_modules are active.

The fix was tested here: https://wash.zowe.org:8443/blue/organizations/jenkins/zowe-cli-sample-plugin/detail/next-publish-test/16/pipeline