### PR TITLE
Fix nightly smoke test

### DIFF
--- a/deploy-constants.yaml
+++ b/deploy-constants.yaml
@@ -35,28 +35,31 @@ packages:
     tags: *ltsTags
   "imperative":
     tags: *npmTags
-  "cli":
-    tags: *npmTags
-  "core-for-zowe-sdk":
-    tags: *npmTags
-  "provisioning-for-zowe-sdk":
-    tags: *npmTags
-  "zos-console-for-zowe-sdk":
-    tags: *npmTags
-  "zos-files-for-zowe-sdk":
-    tags: *npmTags
-  "zos-jobs-for-zowe-sdk":
-    tags: *npmTags
-  "zos-tso-for-zowe-sdk":
-    tags: *npmTags
-  "zos-uss-for-zowe-sdk":
-    tags: *npmTags
-  "zos-workflows-for-zowe-sdk":
-    tags: *npmTags
-  "zosmf-for-zowe-sdk":
-    tags: *npmTags
-  "cli-test-utils":
-    tags: *nextTags
+  "zowe-cli":
+    packages:
+      # Don't change order of monorepo packages
+      "cli-test-utils":
+        tags: *nextTags
+      "core-for-zowe-sdk":
+        tags: *npmTags
+      "zos-uss-for-zowe-sdk":
+        tags: *npmTags
+      "provisioning-for-zowe-sdk":
+        tags: *npmTags
+      "zos-console-for-zowe-sdk":
+        tags: *npmTags
+      "zos-files-for-zowe-sdk":
+        tags: *npmTags
+      "zosmf-for-zowe-sdk":
+        tags: *npmTags
+      "zos-workflows-for-zowe-sdk":
+        tags: *npmTags
+      "zos-jobs-for-zowe-sdk":
+        tags: *npmTags
+      "zos-tso-for-zowe-sdk":
+        tags: *npmTags
+      "cli":
+        tags: *npmTags
   "cics-for-zowe-cli":
     tags: *npmTags
   "db2-for-zowe-cli":

--- a/deploy-constants.yaml
+++ b/deploy-constants.yaml
@@ -36,15 +36,13 @@ packages:
   "imperative":
     tags: *npmTags
   "zowe-cli":
-    packages:
-      # Don't change order of monorepo packages
-      "cli-test-utils":
+    - "cli-test-utils":
         tags: *nextTags
-      "core-for-zowe-sdk":
+    - "core-for-zowe-sdk":
         tags: *npmTags
       "zos-uss-for-zowe-sdk":
         tags: *npmTags
-      "provisioning-for-zowe-sdk":
+    - "provisioning-for-zowe-sdk":
         tags: *npmTags
       "zos-console-for-zowe-sdk":
         tags: *npmTags
@@ -52,13 +50,13 @@ packages:
         tags: *npmTags
       "zosmf-for-zowe-sdk":
         tags: *npmTags
-      "zos-workflows-for-zowe-sdk":
+    - "zos-workflows-for-zowe-sdk":
         tags: *npmTags
       "zos-jobs-for-zowe-sdk":
         tags: *npmTags
       "zos-tso-for-zowe-sdk":
         tags: *npmTags
-      "cli":
+    - "cli":
         tags: *npmTags
   "cics-for-zowe-cli":
     tags: *npmTags

--- a/deploy-constants.yaml
+++ b/deploy-constants.yaml
@@ -36,12 +36,15 @@ packages:
   "imperative":
     tags: *npmTags
   "zowe-cli":
+    # Packages with no monorepo dependencies
     - "cli-test-utils":
         tags: *nextTags
+    # Packages that depend on cli-test-utils
     - "core-for-zowe-sdk":
         tags: *npmTags
       "zos-uss-for-zowe-sdk":
         tags: *npmTags
+    # Packages that depend on core or uss SDK
     - "provisioning-for-zowe-sdk":
         tags: *npmTags
       "zos-console-for-zowe-sdk":
@@ -50,12 +53,14 @@ packages:
         tags: *npmTags
       "zosmf-for-zowe-sdk":
         tags: *npmTags
+    # Packages that depend on files or zosmf SDK
     - "zos-workflows-for-zowe-sdk":
         tags: *npmTags
       "zos-jobs-for-zowe-sdk":
         tags: *npmTags
       "zos-tso-for-zowe-sdk":
         tags: *npmTags
+    # Packages that depend on all the SDKs
     - "cli":
         tags: *npmTags
   "cics-for-zowe-cli":

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -19,7 +19,9 @@ def deployTags(pkgName, props) {
     props.packages.each { subPkgName, subProps ->
       buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
     }
-    return { stages(buildStages) }
+    return {
+      buildStages.each { it.execute() }
+    }
   } else {
     return {
       stage("Deploy: @zowe/${pkgName}") {
@@ -41,7 +43,7 @@ node('ca-jenkins-agent') {
     def constObj = readYaml file: "deploy-constants.yaml"
     def buildStages = [:]
     constObj.packages.each { pkgName, props ->
-      buildStages.put("@zowe/${pkgName}", deployTags(pkgName, props))
+      buildStages.put(props.packages ? pkgName : "@zowe/${pkgName}", deployTags(pkgName, props))
     }
     parallel(buildStages)
   } catch (e) {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -15,12 +15,10 @@ def MASTER_RECIPIENTS_LIST = "andrew.harn@broadcom.com, timothy.johnson@broadcom
 
 def deployTags(pkgName, props) {
   if (props.packages) {
-    def buildStages = [:]
-    props.packages.each { subPkgName, subProps ->
-      buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
-    }
     return {
-      buildStages.each { it.value.execute() }
+      props.packages.each { subPkgName, subProps ->
+        deployTags(subPkgName, subProps)()
+      }
     }
   } else {
     return {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -16,8 +16,8 @@ def MASTER_RECIPIENTS_LIST = "andrew.harn@broadcom.com, timothy.johnson@broadcom
 def deployTags(pkgName, props) {
   if (props.packages) {
     def buildStages = [:]
-    props.packages.each { pkgName, props ->
-      buildStages.put("@zowe/${pkgName}", deployTags(pkgName, props))
+    props.packages.each { subPkgName, subProps ->
+      buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
     }
     return stages(buildStages)
   } else {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -46,10 +46,10 @@ node('ca-jenkins-agent') {
         }
       }
     }
-    parallel {
-      parallel(buildStages)
-      buildGroupStages.each { parallel(it) }
-    }
+    parallel(
+      "a": { parallel(buildStages) }
+      "b": { buildGroupStages.each { parallel(it) } }
+    )
   } catch (e) {
     currentBuild.result = "FAILURE"
     error "${e.getMessage()}"

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -37,11 +37,12 @@ node('ca-jenkins-agent') {
       if (props instanceof Map) {
         buildStages.put("@zowe/${pkgName}", deployTags(pkgName, props))
       } else {
-        props.eachWithIndex { packages, idx ->
-          buildStages.add([:])
+        props.each { packages ->
+          def subBuildStages = [:]
           packages.each { subPkgName, subProps ->
-            buildStages[idx].put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
+            subBuildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
           }
+          buildGroupStages.add(subBuildStages)
         }
       }
     }

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -14,7 +14,17 @@
 def MASTER_RECIPIENTS_LIST = "andrew.harn@broadcom.com, timothy.johnson@broadcom.com, fernando.rijocedeno@broadcom.com"
 
 def deployTags(pkgName, props) {
-  if (props.tags) {
+  if (props instanceof Object[]) {
+    return {
+      props.each { packages ->
+        def buildStages = [:]
+        packages.each { subPkgName, subProps ->
+          buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
+        }
+        parallel(buildStages)
+      }
+    }
+  } else {
     return {
       stage("Deploy: @zowe/${pkgName}") {
         props.tags.each { tagName ->
@@ -26,16 +36,6 @@ def deployTags(pkgName, props) {
         }
       }
     }
-  } else {
-    return {
-      props.each { packages ->
-        def buildStages = [:]
-        packages.each { subPkgName, subProps ->
-          buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
-        }
-        parallel(buildStages)
-      }
-    }
   }
 }
 
@@ -45,7 +45,7 @@ node('ca-jenkins-agent') {
     def constObj = readYaml file: "deploy-constants.yaml"
     def buildStages = [:]
     constObj.packages.each { pkgName, props ->
-      buildStages.put(props.tags ? "@zowe/${pkgName}" : pkgName, deployTags(pkgName, props))
+      buildStages.put(props instanceof Object[] ? pkgName : "@zowe/${pkgName}", deployTags(pkgName, props))
     }
     parallel(buildStages)
   } catch (e) {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -32,25 +32,16 @@ node('ca-jenkins-agent') {
     checkout scm
     def constObj = readYaml file: "deploy-constants.yaml"
     def buildStages = [[:]]
-    echo "a"
     constObj.packages.each { pkgName, props ->
-      echo "b"
       if (props instanceof Map) {
-        echo "c"
         buildStages[0].put("@zowe/${pkgName}", deployTags(pkgName, props))
       } else {
-        echo "d"
         props.eachWithIndex { packages, idx ->
-          echo "e"
           if (buildStages.size() <= idx) {
-            echo "f"
             buildStages.add([:])
           }
-          echo "g"
           packages.each { subPkgName, subProps ->
-            echo "h"
             buildStages[idx].put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
-            echo "i"
           }
         }
       }

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -37,7 +37,7 @@ node('ca-jenkins-agent') {
         buildStages[0].put("@zowe/${pkgName}", deployTags(pkgName, props))
       } else {
         props.eachWithIndex { packages, idx ->
-          if (buildStages.size <= idx) {
+          if (buildStages.size() <= idx) {
             buildStages.add([:])
           }
           packages.each { subPkgName, subProps ->

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -19,7 +19,7 @@ def deployTags(pkgName, props) {
     props.packages.each { subPkgName, subProps ->
       buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
     }
-    return stages(buildStages)
+    return { stages(buildStages) }
   } else {
     return {
       stage("Deploy: @zowe/${pkgName}") {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -14,14 +14,22 @@
 def MASTER_RECIPIENTS_LIST = "andrew.harn@broadcom.com, timothy.johnson@broadcom.com, fernando.rijocedeno@broadcom.com"
 
 def deployTags(pkgName, props) {
-  return {
-    stage("Deploy: @zowe/${pkgName}") {
-      props.tags.each { tagName ->
-        echo "Deploy @zowe/${pkgName}@${tagName}"
-        build job: 'zowe-cli-deploy-component', parameters: [
-          [$class: 'StringParameterValue', name: 'PKG_NAME', value: pkgName],
-          [$class: 'StringParameterValue', name: 'PKG_TAG', value: tagName]
-        ]
+  if (props.packages) {
+    def buildStages = [:]
+    props.packages.each { pkgName, props ->
+      buildStages.put("@zowe/${pkgName}", deployTags(pkgName, props))
+    }
+    return stages(buildStages)
+  } else {
+    return {
+      stage("Deploy: @zowe/${pkgName}") {
+        props.tags.each { tagName ->
+          echo "Deploy @zowe/${pkgName}@${tagName}"
+          build job: 'zowe-cli-deploy-component', parameters: [
+            [$class: 'StringParameterValue', name: 'PKG_NAME', value: pkgName],
+            [$class: 'StringParameterValue', name: 'PKG_TAG', value: tagName]
+          ]
+        }
       }
     }
   }

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -20,7 +20,7 @@ def deployTags(pkgName, props) {
       buildStages.put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
     }
     return {
-      buildStages.each { it.execute() }
+      buildStages.each { it.value.execute() }
     }
   } else {
     return {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -27,6 +27,7 @@ def deployTags(pkgName, props) {
       }
     }
   } else {
+    echo packages.toString()
     return {
       props.each { packages ->
         def buildStages = [:]

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -47,7 +47,7 @@ node('ca-jenkins-agent') {
       }
     }
     parallel(
-      "a": { parallel(buildStages) }
+      "a": { parallel(buildStages) },
       "b": { buildGroupStages.each { parallel(it) } }
     )
   } catch (e) {

--- a/scripts/deploy-zowe-cli-all.groovy
+++ b/scripts/deploy-zowe-cli-all.groovy
@@ -32,16 +32,25 @@ node('ca-jenkins-agent') {
     checkout scm
     def constObj = readYaml file: "deploy-constants.yaml"
     def buildStages = [[:]]
+    echo "a"
     constObj.packages.each { pkgName, props ->
+      echo "b"
       if (props instanceof Map) {
+        echo "c"
         buildStages[0].put("@zowe/${pkgName}", deployTags(pkgName, props))
       } else {
+        echo "d"
         props.eachWithIndex { packages, idx ->
+          echo "e"
           if (buildStages.size() <= idx) {
+            echo "f"
             buildStages.add([:])
           }
+          echo "g"
           packages.each { subPkgName, subProps ->
+            echo "h"
             buildStages[idx].put("@zowe/${subPkgName}", deployTags(subPkgName, subProps))
+            echo "i"
           }
         }
       }

--- a/scripts/deploy-zowe-cli-component.groovy
+++ b/scripts/deploy-zowe-cli-component.groovy
@@ -71,11 +71,14 @@ def VERSIONS_MATCH = true
 
 import java.text.SimpleDateFormat;
 
-node('ca-jenkins-agent') {
+node('zowe-jenkins-agent') {
   try {
     checkout scm
     stage('Deploy package') {
       timeout(time: 10, unit: 'MINUTES') {
+        def nvmInstall = load 'scripts/nvmInstall.groovy'
+        nvmInstall()
+
         PKG_TAG = params.PKG_TAG
         def getPkgInfo = load 'scripts/getPackageInfo.groovy'
         sh "rm -f .npmrc || exit 0"

--- a/scripts/nvmInstall.groovy
+++ b/scripts/nvmInstall.groovy
@@ -20,7 +20,7 @@ def call(String nodeJsVersion = '--lts', String npmVersion = '') {
     // https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
     echo "Updating Node to '${nodeJsVersion == "--lts" ? "lts" : nodeJsVersion}'"
     sh ". ${NVM_DIR}/nvm.sh && nvm install ${nodeJsVersion} && nvm use ${nodeJsVersion} && node -v > .nvmrc"
-    nodeJsVersion = readText(file: ".nvmrc").trim()
+    nodeJsVersion = readFile(file: ".nvmrc").trim()
     env.NODE_PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/lib/node_modules"
     env.PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/bin:${env.PATH}"
 

--- a/scripts/nvmInstall.groovy
+++ b/scripts/nvmInstall.groovy
@@ -1,0 +1,33 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ */
+
+def NVM_DIR = "/home/jenkins/.nvm"
+
+/**
+ * Updates Node.js and NPM in the Docker container to the requested versions
+ * Input: 
+ *  String nodeJsVersion: The desired version of Node.js (defaults to latest LTS)
+ *  String npmVersion: The desired version of NPM (optional)
+ */
+def call(String nodeJsVersion = '--lts', String npmVersion = '') {
+    // https://stackoverflow.com/questions/25899912/how-to-install-nvm-in-docker
+    echo "Updating Node to '${nodeJsVersion == "--lts" ? "lts" : nodeJsVersion}'"
+    sh ". ${NVM_DIR}/nvm.sh && nvm install ${nodeJsVersion} && nvm use ${nodeJsVersion} && node -v > .nvmrc"
+    nodeJsVersion = readText(file: ".nvmrc").trim()
+    env.NODE_PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/lib/node_modules"
+    env.PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/bin:${env.PATH}"
+
+    if (npmVersion != '') {
+        echo "Updating NPM to '${npmVersion}'"
+        sh "npm install -g npm@${npmVersion}"
+    }
+}
+
+return this


### PR DESCRIPTION
Updated Node version in Deploy Component pipeline, to fix packages that fail to install in Node 8 environment.

Also updated Deploy All pipeline to publish monorepo packages sequentially rather than all in parallel, to fix packages that fail to install because one of their dependencies hasn't been deployed yet.

A successful run of the updated pipeline can be seen here: https://wash.zowe.org:8443/blue/organizations/jenkins/zowe-cli-deploy-all/detail/zowe-cli-deploy-all/881/pipeline