### PR TITLE
Add pipeline method to wait for GitHub workflow to complete

### DIFF
--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -1003,7 +1003,7 @@ class GenericPipeline extends Pipeline {
         def gitSlug = scmUrl.minus(".git").split('/')[-2..-1].join('/')
         while (true) {
             def curlOutput = steps.sh(returnStdout: true,
-                script: "curl ${getApiEndpoint()}/repos/${gitSlug}/actions/runs --user \"${GH_USER}:${GH_TOKEN}\"")
+                script: "curl ${getApiEndpoint()}/repos/${gitSlug}/actions/runs --user \"${steps.env.GH_USER}:${steps.env.GH_TOKEN}\"")
             def apiResponse = steps.readJSON(text: curlOutput)
             def numPendingBuilds = 0
             apiResponse.workflow_runs.each {

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -1015,7 +1015,7 @@ class GenericPipeline extends Pipeline {
                 }
             }
             if (numPendingBuilds > 0) {
-                steps.echo "${numPendingBuilds} workflow${(numPendingBuilds > 1) ? 's are' ? ' is'} in progress or queued"
+                steps.echo "${numPendingBuilds} workflow${(numPendingBuilds > 1) ? 's are' : ' is'} in progress or queued"
                 steps.sleep(time: pollTime, unit: 'SECONDS')
             } else {
                 break

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -1002,11 +1002,11 @@ class GenericPipeline extends Pipeline {
      */
     void waitForWorkflow(String name, Integer pollTime = 30) {
         def scmUrl = steps.scm.getUserRemoteConfigs()[0].getUrl()
-        def gitSlug = scmUrl.minus(".git").split('/')[-2..-1].join('/')
+        def repoSlug = scmUrl.minus(".git").split('/')[-2..-1].join('/')
         steps.echo "Waiting for GitHub workflow to complete: ${name}"
         while (true) {
             def curlOutput = steps.sh(returnStdout: true,
-                script: "curl ${getApiEndpoint()}/repos/${gitSlug}/actions/runs --user \"${steps.env.GH_USER}:${steps.env.GH_TOKEN}\"")
+                script: "curl ${getApiEndpoint()}/repos/${repoSlug}/actions/runs --user \"${steps.env.GH_USER}:${steps.env.GH_TOKEN}\"")
             def apiResponse = steps.readJSON(text: curlOutput)
             def numPendingBuilds = 0
             apiResponse.workflow_runs.each {

--- a/src/org/zowe/pipelines/generic/GenericPipeline.groovy
+++ b/src/org/zowe/pipelines/generic/GenericPipeline.groovy
@@ -1003,7 +1003,7 @@ class GenericPipeline extends Pipeline {
     void waitForWorkflow(String name, Integer pollTime = 30) {
         def scmUrl = steps.scm.getUserRemoteConfigs()[0].getUrl()
         def gitSlug = scmUrl.minus(".git").split('/')[-2..-1].join('/')
-        steps.echo "Waiting for workflow to complete: ${name}"
+        steps.echo "Waiting for GitHub workflow to complete: ${name}"
         while (true) {
             def curlOutput = steps.sh(returnStdout: true,
                 script: "curl ${getApiEndpoint()}/repos/${gitSlug}/actions/runs --user \"${steps.env.GH_USER}:${steps.env.GH_TOKEN}\"")


### PR DESCRIPTION
Adds a method `pipeline.waitForWorkflow` that polls the GitHub endpoint [`/repos/<repoName>/actions/runs`](https://docs.github.com/en/rest/reference/actions#list-workflow-runs-for-a-repository) until all workflows that match the given name have completed.

An example of this method working can be seen in this build: https://wash.zowe.org:8443/blue/organizations/jenkins/brightside/detail/test-timothy/6/pipeline/163