### PR TITLE
Update subpackage versions in lockfile

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -500,6 +500,7 @@ class NodeJSPipeline extends GenericPipeline {
                     }
                 } else {
                     steps.sh "npx lerna version ${steps.env.DEPLOY_VERSION} --exact --include-merged-tags --no-git-tag-version --yes"
+                    steps.sh "npm install --package-lock-only"  // Update subpackage versions in lockfile
                 }
 
                 steps.sh "git add -u"  // Safe because we ran "git reset" above


### PR DESCRIPTION
Resolves #156 by ensuring all version updates in lock file get committed.

Unfortunately `npm install --package-lock-only` fails to run at end of version stage, so we run it at end of deploy stage instead which creates a separate commit.