### PR TITLE
Fix shrinkwrap changes not being committed

### DIFF
--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -974,10 +974,10 @@ class NodeJSPipeline extends GenericPipeline {
                     if (!changeInfo.isPullRequest) {
                         // Add package and package lock to the commit tree. This will not fail if
                         // unable to add an item for any reasons.
-                        steps.sh "git add package.json package-lock.json npm-shrinkwrap.json --ignore-errors || exit 0"
+                        steps.sh "git add package.json; git add package-lock.json; git add npm-shrinkwrap.json || exit 0"
                         if (isLernaMonorepo) {
                             runForEachMonorepoPackage(LernaFilter.ALL) {
-                                steps.sh "git add package.json --ignore-errors || exit 0"
+                                steps.sh "git add package.json || exit 0"
                             }
                         }
                         gitCommit("Updating dependencies")


### PR DESCRIPTION
The `--ignore-errors` flag does not behave like we thought. If one of the files listed in the command does not exist, then none of the files get staged. This was preventing dependency updates in `npm-shrinkwrap.json` from getting committed.