### PR TITLE
fix: handle no node version :yum:

### DIFF
--- a/scripts/nvmInstall.groovy
+++ b/scripts/nvmInstall.groovy
@@ -25,7 +25,7 @@ def call(String nodeJsVersion = '--lts', String npmVersion = '') {
         env.NODE_PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/lib/node_modules"
         env.PATH = "${NVM_DIR}/versions/node/${nodeJsVersion}/bin:${env.PATH}"
     } else if (sh(returnStatus: true, script: "which n") == 0) {
-        sh "sudo n install ${nodeJsVersion == "--lts" ? "lts" : nodeJsVersion}'"
+        sh "sudo n install ${nodeJsVersion == "--lts" || arguments.nodeJsVersion == null ? "lts" : nodeJsVersion}'"
     } else {
         error "Node.js version managers (NVM, N) are not available or not properly configured. Please ensure either NVM or N are configured in your Docker container."
     }

--- a/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
+++ b/src/org/zowe/pipelines/nodejs/NodeJSPipeline.groovy
@@ -913,7 +913,7 @@ class NodeJSPipeline extends GenericPipeline {
                 steps.env.NODE_PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/lib/node_modules"
                 steps.env.PATH = "${arguments.nvmDir}/versions/node/${arguments.nodeJsVersion}/bin:${steps.env.PATH}"
             } else if (steps.sh(returnStatus: true, script: "which n") == 0) {
-                steps.sh "sudo n install ${arguments.nodeJsVersion == "--lts" ? "lts" : arguments.nodeJsVersion}"
+                steps.sh "sudo n install ${arguments.nodeJsVersion == "--lts" || arguments.nodeJsVersion == null ? "lts" : arguments.nodeJsVersion}"
             } else {
                 steps.error "Node.js version managers (NVM, N) are not available or not properly configured. Please ensure either NVM or N are configured in your Docker container."
             }


### PR DESCRIPTION
When `pipeline.setup()` doesn't provide a node version, the install step fails.

| Before |  After |
| - | - |
| ![image](https://github.com/user-attachments/assets/6bfff17b-c86a-4652-973a-2c24b965068c) | ![image](https://github.com/user-attachments/assets/5d5e0918-c7be-4809-97eb-6cb7c6277510) |